### PR TITLE
adding in an example docs structure

### DIFF
--- a/build-docs.js
+++ b/build-docs.js
@@ -1,0 +1,15 @@
+const fs = require('fs')
+const glob = require('glob')
+const Remarkable = require('remarkable')
+
+const md = new Remarkable()
+
+const docs = glob
+    .sync('./packages/**/readme.md')
+    .map(file => md.render(fs.readFileSync(file, { encoding: 'utf8' })))
+    .join('\n\n')
+
+fs.writeFileSync(
+    './docs/index.html',
+    fs.readFileSync('./docs/template.html', { encoding: 'utf8' }).replace('<!-- content -->', docs)
+)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>fujs docs</title>
+    </head>
+    <body>
+        <p>Use it like this:</p>
+<pre><code class="language-js">import filter from '@fujs/filter'
+
+const arr = [
+    { number: 20 },
+    { number: 12 },
+    { number: 47 }
+]
+const bigEnough = obj =&gt; obj.number &gt; 30
+filter(bigEnough, arr) // =&gt; [{ number: 47 }]
+</code></pre>
+
+    </body>
+</html>

--- a/docs/template.html
+++ b/docs/template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>fujs docs</title>
+    </head>
+    <body>
+<!-- content -->
+    </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
     "babel-preset-env": "^1.2.2",
     "babel-register": "^6.24.0",
     "benchmark": "^2.1.3",
+    "glob": "^7.1.1",
     "lerna": "2.0.0-beta.38",
     "onchange": "^3.2.1",
+    "remarkable": "^1.7.1",
     "tape": "^4.6.3"
   }
 }

--- a/packages/filter/readme.md
+++ b/packages/filter/readme.md
@@ -1,0 +1,13 @@
+Use it like this:
+
+```js
+import filter from '@fujs/filter'
+
+const arr = [
+    { number: 20 },
+    { number: 12 },
+    { number: 47 }
+]
+const bigEnough = obj => obj.number > 30
+filter(bigEnough, arr) // => [{ number: 47 }]
+```


### PR DESCRIPTION
What do you think about something like this?

Basically you'd need to add a readme into each folder, and add some prettier styles to the `template.html` file, but then you can use Github pages and point it to the `/docs` folder for sweet documentation.

That would be a pretty simple way to get docs going.

Other things would be to run [jsmd](https://www.npmjs.com/package/jsmd) on the readme files, to make sure the examples are always correct, and you might eventually want to add a [frontmatter parser](https://github.com/jonschlinkert/gray-matter) to add metadata to each readme, but that can come with time.